### PR TITLE
Fix: 편집 페이지 퀴즈 타이틀에 NaN 문제 해결

### DIFF
--- a/client/src/pages/host/EditPage.js
+++ b/client/src/pages/host/EditPage.js
@@ -134,7 +134,10 @@ function EditPage() {
         </SideBar>
         <Main>
           <TitleWrapper>
-            <FlexibleInput />
+            <FlexibleInput
+              maxLength={120}
+              placeholder="문제를 입력해주세요."
+            />
             <OptionImage />
           </TitleWrapper>
           <QuizDetailContainer>


### PR DESCRIPTION
### Done
- editPage.js에서 컴포넌트 생성 시 props로 전달

### Related Issue
#62