### PR TITLE
[이수정]w3_리뷰요청_소켓통신 기능 업데이트 및 상세 방 페이지 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/client/src/components/detailRoom/RoomInformation.js
+++ b/client/src/components/detailRoom/RoomInformation.js
@@ -1,0 +1,68 @@
+import React, { useState, useEffect } from "react";
+import styled from "styled-components";
+import * as colors from "../../constants/colors";
+
+const RoomInformationContainer = styled.div`
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  span {
+    color: ${colors.TEXT_WHITE};
+    font-weight: bold;
+    font-size: 2rem;
+    text-shadow: 1px 1px 3px ${colors.TEXT_BLACK};
+    margin-left: 1rem;
+  }
+`;
+
+const EditRoomNameImage = styled.img.attrs({
+  src:
+    "https://iconmonstr.com/wp-content/g/gd/makefg.php?i=../assets/preview/2012/png/iconmonstr-edit-4.png&r=255&g=255&b=255"
+})`
+  width: 2.5rem;
+  cursor: pointer;
+  opacity: 0.6;
+  &:hover {
+    text-decoration: underline;
+    opacity: 1;
+  }
+`;
+
+/**
+ * 방 리스트 페이지에서 방 ID를 넘겨줌
+ * 방 상세 페이지 루트 컴포넌트는 이 컴포넌트에 방 ID 전달
+ * 방 ID를 통해서 마운트 될 때 방 이름 가져옴.
+ */
+function RoomInformation() {
+  const [roomName, setRoomName] = useState("");
+
+  useEffect(() => {
+    /**
+     * fetch using roomId, init roomName
+     */
+    setRoomName("방 이름");
+  }, []);
+
+  function handleRoomName() {
+    /**
+     * 현재 방의 이름을 Modal input에 출력
+     * 유저가 입력한 값을 setRoomName로 설정하고 fetch
+     * 응답이 실패로 왔을 경우 상태를 이전으로 돌리고 유저에게 알림
+     * */
+    const currentRoomName = roomName;
+    setRoomName(currentRoomName);
+  }
+
+  return (
+    <>
+      <RoomInformationContainer>
+        <span>{roomName}</span>
+        <EditRoomNameImage title="이름 수정하기" onClick={handleRoomName} />
+      </RoomInformationContainer>
+    </>
+  );
+}
+
+export default RoomInformation;

--- a/client/src/components/detailRoom/TabContents.js
+++ b/client/src/components/detailRoom/TabContents.js
@@ -1,0 +1,76 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import * as colors from "../../constants/colors";
+
+const NavigationBar = styled.nav`
+  display: flex;
+  background-color: ${colors.BACKGROUND_LIGHT_WHITE};
+  height: 5rem;
+  box-shadow: 0 5px 5px -4px ${colors.TEXT_GRAY};
+  justify-content: center;
+  align-items: center;
+`;
+
+const TabMenuButton = styled.div`
+  border-bottom: ${props =>
+    props.isSelected ? `3px solid ${colors.TEXT_BLACK}` : `none`};
+  background-color: ${colors.BACKGROUND_LIGHT_WHITE};
+  font-weight: bold;
+  font-size: 2rem;
+  color: ${colors.TEXT_BLACK};
+  margin-right: 1rem;
+  cursor: pointer;
+  &:hover {
+    border-bottom: 3px solid ${colors.TEXT_BLACK};
+  }
+  &:focus {
+    outline: none;
+  }
+`;
+
+function TabContents() {
+  const [isQuizMenuSelected, setQuizMenuState] = useState(true);
+  const [isAnalysisMenuSelected, setAnalysisMenuState] = useState(false);
+
+  function resetMenuState() {
+    setQuizMenuState(false);
+    setAnalysisMenuState(false);
+  }
+
+  function handleQuizMenuClick() {
+    resetMenuState();
+    setQuizMenuState(true);
+  }
+
+  function handleAnalysisMenuClick() {
+    resetMenuState();
+    setAnalysisMenuState(true);
+  }
+
+  return (
+    <>
+      <NavigationBar>
+        <TabMenuButton
+          type="button"
+          onClick={handleQuizMenuClick}
+          isSelected={isQuizMenuSelected}
+        >
+          퀴즈
+        </TabMenuButton>
+        <TabMenuButton
+          type="button"
+          onClick={handleAnalysisMenuClick}
+          isSelected={isAnalysisMenuSelected}
+        >
+          분석
+        </TabMenuButton>
+      </NavigationBar>
+      <main>
+        {isQuizMenuSelected && <>퀴즈 컴포넌트</>}
+        {isAnalysisMenuSelected && <>분석 컴포넌트</>}
+      </main>
+    </>
+  );
+}
+
+export default TabContents;

--- a/client/src/pages/host/HostDetailRoom.js
+++ b/client/src/pages/host/HostDetailRoom.js
@@ -1,0 +1,51 @@
+import React from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import * as colors from "../../constants/colors";
+import Header from "../../components/common/Header";
+import { YellowButton } from "../../components/common/Buttons";
+import TabContents from "../../components/detailRoom/TabContents";
+import RoomInformation from "../../components/detailRoom/RoomInformation";
+
+const Background = styled.div`
+  height: 100%;
+  background-color: ${colors.BACKGROUND_LIGHT_GRAY};
+`;
+
+const ButtonContainer = styled.div`
+  position: absolute;
+  right: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+`;
+
+function DetailRoom({ history }) {
+  function handlePlayButton() {
+    /**
+     * 퀴즈를 시작할 것인지 확인하는 Modal 출력
+     */
+    history.push({
+      pathname: "/host"
+    });
+  }
+
+  return (
+    <Background>
+      <Header>
+        <RoomInformation />
+        <ButtonContainer>
+          <YellowButton onClick={handlePlayButton}>시작하기</YellowButton>
+        </ButtonContainer>
+      </Header>
+      <TabContents />
+    </Background>
+  );
+}
+
+DetailRoom.propTypes = {
+  history: PropTypes.shape({
+    push: PropTypes.func.isRequired
+  }).isRequired
+};
+
+export default DetailRoom;

--- a/client/src/pages/host/HostWaitingRoom.js
+++ b/client/src/pages/host/HostWaitingRoom.js
@@ -1,0 +1,65 @@
+import React, { useState, useEffect } from "react";
+import styled from "styled-components";
+import io from "socket.io-client";
+import * as colors from "../../constants/colors";
+import Header from "../../components/common/Header";
+import HostFooter from "../../components/inGame/HostFooter";
+import { YellowButton } from "../../components/common/Buttons";
+
+/**
+ * 코드리뷰를 위해 일부 컴포넌트는 삭제되어 있습니다.
+ * styled component: Container, ButtonContainer, RoomInformation, Main, PlayerCounter, PlayerList
+ */
+
+function HostWaitingRoom() {
+  const [players, setPlayers] = useState([]);
+  const [roomNumber, setRoomNumber] = useState("");
+  const socket = io.connect(process.env.REACT_APP_BACKEND_HOST);
+
+  useEffect(() => {
+    socket.emit("openRoom");
+    socket.on("openRoom", roomCode => {
+      setRoomNumber(roomCode.roomNumber);
+    });
+
+    return () => {
+      socket.emit("closeRoom");
+    };
+  }, []);
+
+  socket.on("enterPlayer", playerList => {
+    setPlayers(playerList);
+  });
+
+  socket.on("leavePlayer", playerList => {
+    setPlayers(playerList);
+  });
+
+  function startQuiz() {
+    socket.emit("startQuiz", { roomNumber });
+  }
+
+  return (
+    <Container>
+      <Header>
+        <RoomInformation>
+          방 번호 <strong>{roomNumber}</strong>
+        </RoomInformation>
+        <ButtonContainer>
+          <YellowButton onClick={startQuiz}>Start</YellowButton>
+        </ButtonContainer>
+      </Header>
+      <Main>
+        <PlayerCounter>대기자 {players.length}명</PlayerCounter>
+        <PlayerList>
+          {players.map(player => (
+            <li key={player.nickname}>{player.nickname}</li>
+          ))}
+        </PlayerList>
+      </Main>
+      <HostFooter roomNumber={roomNumber} />
+    </Container>
+  );
+}
+
+export default HostWaitingRoom;

--- a/client/src/pages/player/PlayerWaitingRoom.js
+++ b/client/src/pages/player/PlayerWaitingRoom.js
@@ -1,0 +1,73 @@
+import React, { useState, useEffect } from "react";
+import styled, { keyframes } from "styled-components";
+import io from "socket.io-client";
+import PropTypes from "prop-types";
+import * as colors from "../../constants/colors";
+import PlayerFooter from "../../components/inGame/PlayerFooter";
+import ProgressBar from "../../components/inGame/ProgressBar";
+import DESKTOP_MIN_WIDTH from "../../constants/media";
+
+/**
+ * 코드리뷰를 위해 일부 컴포넌트는 삭제되어 있습니다.
+ * styled component: Container, Main, LoadingAnimation, LoadigImage, LoadingText, Saying
+ * jsx component: BeforeStart(), AfterStart()
+ */
+
+function PlayerWaitingRoom({ location, history }) {
+  const [isQuizStart, setQuizStart] = useState(false);
+  const socket = io.connect(process.env.REACT_APP_BACKEND_HOST);
+
+  useEffect(() => {
+    socket.emit("enterPlayer", {
+      nickname: location.state.nickname,
+      roomNumber: location.state.roomNumber
+    });
+
+    return () => {
+      /**
+       * react-router의 Prompt를 사용하면 페이지를 나가는 것을 막을 수 있지만
+       * 아래 closeRoom 수신 시 history.push가 정상동작하지 않는 문제가 있음.
+       */
+      socket.emit("leavePlayer", {
+        nickname: location.state.nickname,
+        roomNumber: location.state.roomNumber
+      });
+    };
+  }, []);
+
+  socket.on("startQuiz", () => {
+    setQuizStart(true);
+  });
+
+  socket.on("closeRoom", () => {
+    /**
+     * 사용자에게 Modal로 방이 닫혔음을 알림
+     * 사용자가 어떤 형태로든 창을 닫으면 경로를 바꾼다.
+     */
+    history.push({
+      pathname: "/"
+    });
+  });
+
+  return (
+    <Container>
+      <Main>{!isQuizStart ? BeforeStart() : AfterStart()}</Main>
+      <PlayerFooter nickname={location.state.nickname} />
+    </Container>
+  );
+}
+
+PlayerWaitingRoom.propTypes = {
+  location: PropTypes.shape({
+    pathname: PropTypes.string.isRequired,
+    state: PropTypes.shape({
+      nickname: PropTypes.string.isRequired,
+      roomNumber: PropTypes.string.isRequired
+    })
+  }).isRequired,
+  history: PropTypes.shape({
+    push: PropTypes.func.isRequired
+  }).isRequired
+};
+
+export default PlayerWaitingRoom;

--- a/server/models/rooms.js
+++ b/server/models/rooms.js
@@ -1,0 +1,54 @@
+class Rooms {
+  constructor() {
+    this.rooms = [];
+  }
+
+  pushRoom(room) {
+    this.rooms.push(room);
+    const index = this.rooms.length;
+
+    return index;
+  }
+
+  pushPlayer(roomNumber, player) {
+    const room = this.getRoom(roomNumber);
+    room.players.push(player);
+    return true;
+  }
+
+  getRoom(roomNumber) {
+    return this.rooms.find(room => room.roomNumber === roomNumber);
+  }
+
+  getNewRoomNumber() {
+    let newRoomNumber = 111111;
+
+    while (this.getRoom(String(newRoomNumber))) {
+      newRoomNumber = Math.floor(Math.random() * 899999 + 100000);
+    }
+
+    return String(newRoomNumber);
+  }
+
+  removePlayer(roomNumber, nickname) {
+    const playersRoom = this.getRoom(roomNumber);
+    const playerIndex = playersRoom.players.findIndex(
+      player => player.nickname === nickname
+    );
+    playersRoom.players.splice(playerIndex, 1);
+
+    return playersRoom;
+  }
+
+  removeRoom(hostId) {
+    const roomIndex = this.rooms.findIndex(room => room.hostId === hostId);
+    const { roomNumber } = this.rooms[roomIndex];
+
+    this.rooms.splice(roomIndex, 1);
+    return roomNumber;
+  }
+}
+
+const rooms = new Rooms();
+
+module.exports = rooms;

--- a/server/models/templates/player.js
+++ b/server/models/templates/player.js
@@ -1,0 +1,6 @@
+const playerTemplate = () => ({
+  nickname: "",
+  score: 0
+});
+
+module.exports = playerTemplate;

--- a/server/models/templates/quiz.js
+++ b/server/models/templates/quiz.js
@@ -1,0 +1,15 @@
+const quizTemplate = () => ({
+  title: "",
+  items: [],
+  answer: -1
+});
+
+const itemTemplate = () => ({
+  title: "",
+  playerCount: 0
+});
+
+module.exports = {
+  quizTemplate,
+  itemTemplate
+};

--- a/server/models/templates/room.js
+++ b/server/models/templates/room.js
@@ -1,0 +1,9 @@
+const roomTemplate = () => ({
+  roomNumber: "",
+  players: [],
+  hostId: "",
+  package: [],
+  currentQuizIndex: -1
+});
+
+module.exports = roomTemplate;

--- a/server/socket.js
+++ b/server/socket.js
@@ -1,0 +1,66 @@
+const io = require("socket.io")();
+const rooms = require("./models/rooms");
+const roomTemplate = require("./models/templates/room");
+const playerTemplate = require("./models/templates/player");
+
+function handleOpenRoom() {
+  const roomNumber = rooms.getNewRoomNumber();
+  const newRoom = roomTemplate();
+
+  newRoom.hostId = this.id;
+  newRoom.roomNumber = roomNumber;
+
+  rooms.pushRoom(newRoom);
+
+  this.join(roomNumber, () => {
+    io.to(newRoom.hostId).emit("openRoom", { roomNumber });
+  });
+}
+
+function isRoomExist(roomNumber) {
+  return rooms.getRoom(roomNumber);
+}
+
+function handleStartQuiz({ roomNumber }) {
+  if (!isRoomExist(roomNumber)) return;
+
+  io.to(roomNumber).emit("startQuiz");
+}
+
+function handleEnterPlayer({ roomNumber, nickname }) {
+  if (!isRoomExist(roomNumber)) return;
+
+  const currentRoom = rooms.getRoom(roomNumber);
+  const newPlayer = playerTemplate();
+  newPlayer.nickname = nickname;
+
+  rooms.pushPlayer(roomNumber, newPlayer);
+
+  this.join(roomNumber, () => {
+    io.to(currentRoom.hostId).emit("enterPlayer", currentRoom.players);
+  });
+}
+
+function handleLeavePlayer({ roomNumber, nickname }) {
+  if (!isRoomExist(roomNumber)) return;
+  const playerRoom = rooms.removePlayer(roomNumber, nickname);
+
+  this.join(roomNumber, () => {
+    io.to(playerRoom.hostId).emit("leavePlayer", playerRoom.players);
+  });
+}
+
+function handleCloseRoom() {
+  const roomNumber = rooms.removeRoom(this.id);
+  io.to(roomNumber).emit("closeRoom");
+}
+
+io.on("connection", socket => {
+  socket.on("openRoom", handleOpenRoom.bind(socket));
+  socket.on("closeRoom", handleCloseRoom.bind(socket));
+  socket.on("startQuiz", handleStartQuiz.bind(socket));
+  socket.on("enterPlayer", handleEnterPlayer.bind(socket));
+  socket.on("leavePlayer", handleLeavePlayer.bind(socket));
+});
+
+module.exports = io;


### PR DESCRIPTION
## 개발 상황 요약
### 3주차 데모 시나리오
- 로그인한 사용자만 방을 열 수 있고, **상세 방 페이지에서 Host가 방을 열면 6자리 코드가 생성되어 인메모리에 저장된다.** 
- **Player는 입장한 방에 맞게 연결되고 Host의 신호에 따라 퀴즈가 시작된다.**
- Host가 열지 않은 방에 Player는 들어갈 수 없으며, 그에 따른 경고를 출력한다. 
- 같은 방에 중복된 닉네임을 검사하고 경고를 출력한다.

위 데모 시나리오에서 Bold 처리된 부분을 담당하였습니다. 

<details><summary>리뷰 디렉토리 구조</summary>

```bash
client/src
 \ components
      \ detailRoom # HostDetailRoom.js에 호출되는 컴포넌트 입니다.
          \ RoomInformation.js
          \ TabContents.js
  \ pages
      \ host
          \ HostDetailRoom.js # 상세 방 페이지의 최상위 컴포넌트 입니다.
          \ HostWaitingRoom.js # Host의 퀴즈 대기실 페이지 입니다. 
            # Player의 입장 신호를 받고, 게임 시작 등의 신호를 전송합니다.
      \ player
          \ PlayerWaitingRoom.js # Player의 퀴즈 대기실 페이지 입니다. 
            # 입장 신호를 보내고, 게임 시작 신호를 받아 카운트 다운이 시작됩니다. 
server
  \ models
      \ templates # 인메모리에 저장되는 객체의 기본 템플릿입니다.
          \ player.js
          \ quiz.js
          \ room.js 
      \ rooms.js # 인메모리에 저장되는 정보의 클래스 입니다. 
  \ socket.js # 소켓 통신을 받는 파일입니다. 
```
</details>

### 작업 관련 이슈
#35 #32 

## 질문 및 의견

1. **하나의 객체만 저장하는 Wrapper 클래스 이슈**

인메모리에 저장되는 값이 방 정보 뿐이어서, 조금 포괄적인 `inMemory.js`라는 이름에서 `rooms.js`라는 이름으로 파일 이름을 변경하였습니다. 그런데 `rooms.js`라는 이름도 의미 전달이 잘 되는 편은 아닌 것 같아서, 팀원이 `inMemory.rooms.~`같은 형태는 어떤지 제안을 했었는데요. #53

의미를 전달하기 위해 Wrapper 형태의 새로운 클래스를 만드는 것이 괜찮은 방법일까요? Wrapper 안에 저장될 정보가 하나 뿐이라서 조금 고민이 되는 부분입니다.  
  
2. **Prompt와 history, Player의 페이지 강제 이동 이슈**

Player와 Host 대기실에서, 페이지를 이동하면 socket 연결이 끊기기 때문에 유저에게 이런 상황을 알려줘야 될 필요를 느꼈습니다.   

찾아보니 `react-router`에서 `Prompt`라는 컴포넌트를 사용하면 페이지를 나가는 상황을 막을 수 있었는데, 이렇게 하니 history로 페이지 이동을 push하는 작업이 먹히지 않는 이슈가 있었습니다.  
  
이 방법 외에도 `window` 객체의 `beforeunload`를 활용하는 방안이 있었는데, react에서 직접적으로 window 객체를 접근하는 것이 일반적일까요? 다른 방법이 있다면 무엇이 있을까요?

```javascript
//PlayerWaitingRoom.js
  socket.on("closeRoom", () => {
    /**
     * 사용자에게 Modal로 방이 닫혔음을 알림
     * 사용자가 어떤 형태로든 창을 닫으면 경로를 바꾼다.
     */
    history.push({
      pathname: "/"
    });
  });
```

3. **탭 메뉴에 따른 State 관리**

탭 메뉴를 누를 때 마다 다른 컴포넌트를 보여주기 위해, 아래 처럼 컴포넌트별 state를 만들어서 true가 될 때 보이도록 구현하였습니다.  

그런데 이렇게 구현하게 되면 메뉴가 늘어날 때 마다 state가 늘어나게 되서 보기 좋지 않을 것 같은데, 보통은 이런 경우 어떤 방식을 사용하나요? 
```javascript
//HostDetailRoom.js
  const [isQuizMenuSelected, setQuizMenuState] = useState(true);
  const [isAnalysisMenuSelected, setAnalysisMenuState] = useState(false);
  ...
      <main>
        {isQuizMenuSelected && <>퀴즈 컴포넌트</>}
        {isAnalysisMenuSelected && <>분석 컴포넌트</>}
      </main>
```