### PR TITLE
[이수정]w4_리뷰요청_Host 페이지 게임 진행 상태관리 및 api 리팩토링

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/client/src/components/inGame/HostLoading.js
+++ b/client/src/components/inGame/HostLoading.js
@@ -1,0 +1,34 @@
+/**
+ * module import 생략
+ * Styled-component 생략; Container, Main, Notify
+ */
+function HostLoading({ state, dispatcher }) {
+  useEffect(() => {
+    fetchQuizSet(state.roomNumber).then(response => {
+      dispatcher({
+        type: "setFullQuiz",
+        data: response.quizSet
+      });
+    });
+  }, []);
+  return (
+    <Container>
+      <Main>
+        <Notify>
+          퀴즈가 준비 중이에요 <br />
+          잠시 기다려주세요
+        </Notify>
+        <ProgressBar animationDurationSeconds={3} />
+      </Main>
+    </Container>
+  );
+}
+
+HostLoading.propTypes = {
+  dispatcher: PropTypes.func.isRequired,
+  state: PropTypes.shape({
+    roomNumber: PropTypes.string.isRequired
+  }).isRequired
+};
+
+export default HostLoading;

--- a/client/src/components/inGame/HostPlaying.js
+++ b/client/src/components/inGame/HostPlaying.js
@@ -1,0 +1,51 @@
+/**
+ * module import 생략
+ * Styled-Component 생략: ButtonContainer, QuizContainer, RemainTime
+ */
+function HostPlaying({ state, dispatcher }) {
+  const [remainTime, setRemainTime] = useState(0);
+
+  useEffect(() => {
+    setRemainTime(Number(state.currentQuiz.timeLimit));
+    const timer = setInterval(() => {
+      setRemainTime(cur => {
+        if (cur === 0) {
+          clearInterval(timer);
+          dispatcher({ type: "break" });
+          return 0;
+        }
+        return cur - 1;
+      });
+    }, 1000);
+
+    return () => {
+      clearInterval(timer);
+    };
+  }, [state.currentQuiz]);
+
+  return (
+    <>
+      <ButtonContainer>
+        <GreenButton
+          onClick={() => {
+            dispatcher({ type: "break" });
+          }}
+        >
+          다음퀴즈
+        </GreenButton>
+      </ButtonContainer>
+      <QuizContainer>
+        <RemainTime>{remainTime}</RemainTime>
+      </QuizContainer>
+    </>
+  );
+}
+
+HostPlaying.propTypes = {
+  state: PropTypes.shape({
+    currentQuiz: PropTypes.object.isRequired
+  }).isRequired,
+  dispatcher: PropTypes.func.isRequired
+};
+
+export default HostPlaying;

--- a/client/src/components/inGame/HostQuizPlayingRoom.js
+++ b/client/src/components/inGame/HostQuizPlayingRoom.js
@@ -1,0 +1,47 @@
+/**
+ * module import 생략
+ * Styled-Componet 생략: Container, Title, ItemContaier, QuizInformation
+ */
+function HostQuizPlayingRoom({ state, dispatcher }) {
+  const [showSubResult, setSubResultState] = useState(false);
+
+  useEffect(() => {
+    if (state.quizSubResult) {
+      setSubResultState(true);
+    }
+  }, [state.quizSubResult]);
+
+  useEffect(() => {
+    setSubResultState(false);
+  }, [state.currentQuiz]);
+
+  return (
+    <Container>
+      <Title>
+        <QuizInformation>
+          {state.currentQuiz.index + 1}/{state.totalQuizCount}
+        </QuizInformation>
+        {state.currentQuiz.title}
+      </Title>
+      {!showSubResult && <HostPlaying state={state} dispatcher={dispatcher} />}
+      {showSubResult && <HostSubResult state={state} dispatcher={dispatcher} />}
+      <ItemContainer>
+        <li style={{ backgroundColor: colors.ITEM_COLOR[0] }}>
+          {state.currentQuiz.items[0].title}
+        </li>
+        {/* 동일한 구조 <li> 3개 생략 */}
+      </ItemContainer>
+    </Container>
+  );
+}
+
+HostQuizPlayingRoom.propTypes = {
+  state: PropTypes.shape({
+    quizSubResult: PropTypes.array,
+    currentQuiz: PropTypes.object.isRequired,
+    totalQuizCount: PropTypes.number.isRequired
+  }).isRequired,
+  dispatcher: PropTypes.func.isRequired
+};
+
+export default HostQuizPlayingRoom;

--- a/client/src/components/inGame/HostSubResult.js
+++ b/client/src/components/inGame/HostSubResult.js
@@ -1,0 +1,43 @@
+/**
+ * module import 생략
+ * Styled-Component 생략: ButtonContainer, ScoreChartContainer
+ */
+function HostSubResult({ state, dispatcher }) {
+  const itemDatas = state.quizSubResult.map((cur, index) => {
+    if (state.currentQuiz.answer.includes(index)) {
+      return { ...cur, isAnswer: true };
+    }
+    return { ...cur, isAnswer: false };
+  });
+  return (
+    <>
+      <ButtonContainer>
+        <GreenButton
+          onClick={() => {
+            if (state.currentQuiz.index === state.totalQuizCount - 1) {
+              dispatcher({ type: "scoreBoard" });
+              return;
+            }
+            dispatcher({ type: "next" });
+          }}
+        >
+          다음퀴즈
+        </GreenButton>
+      </ButtonContainer>
+      <ScoreChartContainer>
+        <ScoreChart itemDatas={itemDatas} />
+      </ScoreChartContainer>
+    </>
+  );
+}
+
+HostSubResult.propTypes = {
+  state: PropTypes.shape({
+    quizSubResult: PropTypes.array.isRequired,
+    currentQuiz: PropTypes.object.isRequired,
+    totalQuizCount: PropTypes.number.isRequired
+  }).isRequired,
+  dispatcher: PropTypes.func.isRequired
+};
+
+export default HostSubResult;

--- a/client/src/pages/host/HostGameRoom.js
+++ b/client/src/pages/host/HostGameRoom.js
@@ -1,0 +1,53 @@
+/**
+ * module import 생략
+ */
+function HostGameRoom() {
+  const socket = io.connect(process.env.REACT_APP_BACKEND_HOST);
+  const [roomState, dispatcher] = useReducer(roomReducer, initialRoomState);
+
+  useEffect(() => {
+    dispatcher({ type: "socket", socket });
+    socket.emit("openRoom");
+    socket.on("openRoom", ({ roomNumber }) => {
+      dispatcher({ type: "roomNumber", roomNumber });
+    });
+
+    window.addEventListener("beforeunload", e => {
+      e.returnValue = "warning";
+    });
+
+    return () => {
+      socket.emit("closeRoom");
+    };
+  }, []);
+
+  //   socket.on("enterPlayer", players => {
+  //   socket.on("leavePlayer", players => {
+
+  socket.on("next", nextQuizIndex => {
+    dispatcher({ type: "setCurrentQuiz", index: nextQuizIndex });
+  });
+
+  socket.on("subResult", subResult => {
+    dispatcher({ type: "setSubResult", subResult });
+  });
+
+  return (
+    <Container>
+      <Prompt message="페이지를 이동하면 방이 닫힐 수 있습니다. 계속 하시겠습니까?" />
+      {!roomState.isQuizStart && !roomState.currentQuiz && (
+        <HostWaitingRoom dispatcher={dispatcher} state={roomState} />
+      )}
+      {roomState.isQuizStart && !roomState.currentQuiz && (
+        <HostLoading state={roomState} dispatcher={dispatcher} />
+      )}
+      {roomState.currentQuiz && !roomState.isQuizEnd && (
+        <HostQuizPlayingRoom dispatcher={dispatcher} state={roomState} />
+      )}
+      {roomState.isQuizEnd && <GameResult />}
+      <HostFooter roomNumber={roomState.roomNumber} />
+    </Container>
+  );
+}
+
+export default HostGameRoom;

--- a/client/src/reduecer/hostGameReducer.js
+++ b/client/src/reduecer/hostGameReducer.js
@@ -1,0 +1,71 @@
+const roomReducer = (state, action) => {
+  switch (action.type) {
+    case "socket": {
+      return { ...state, socket: action.socket };
+    }
+    case "roomNumber": {
+      return { ...state, roomNumber: action.roomNumber };
+    }
+    case "players": {
+      return { ...state, players: action.players };
+    }
+    case "start": {
+      state.socket.emit("start", { roomNumber: state.roomNumber });
+      return { ...state, isQuizStart: true };
+    }
+    case "setCurrentQuiz": {
+      return {
+        ...state,
+        currentQuiz: {
+          ...state.fullQuizData[action.index],
+          index: action.index
+        }
+      };
+    }
+    case "next": {
+      state.socket.emit("next", {
+        roomNumber: state.roomNumber,
+        nextQuizIndex: state.currentQuiz.index + 1
+      });
+
+      return state;
+    }
+    case "break": {
+      state.socket.emit("break", {
+        roomNumber: state.roomNumber,
+        quizIndex: state.currentQuiz.index
+      });
+
+      return state;
+    }
+    case "setSubResult": {
+      return { ...state, quizSubResult: action.subResult };
+    }
+    case "setFullQuiz": {
+      return {
+        ...state,
+        fullQuizData: action.data,
+        totalQuizCount: action.data.length
+      };
+    }
+    case "scoreBoard": {
+      return { ...state, isQuizEnd: true };
+    }
+    default:
+      return state;
+  }
+};
+
+const initialRoomState = {
+  roomNumber: "",
+  players: [],
+  socket: null,
+  fullQuizData: [],
+  totalQuizCount: 0,
+  isQuizStart: false,
+  isQuizEnd: false,
+  currentQuiz: null,
+  quizSubResult: null
+};
+
+export { initialRoomState, roomReducer };

--- a/server/middleware/validation.js
+++ b/server/middleware/validation.js
@@ -1,0 +1,105 @@
+const { check, validationResult } = require("express-validator");
+const rooms = require("../models/rooms");
+
+//  * 방 번호를 입력 받아서 값이 유효한지 확인함. (6자리 체크, 숫자가 아닌지 체크)
+async function isRoomNumberValid(req, res, next) {
+  await check("roomNumber")
+    .trim()
+    .isLength(6)
+    .bail()
+    .isNumeric()
+    .run(req);
+
+  if (!validationResult(req).isEmpty()) {
+    res.json({
+      isSuccess: false,
+      message: "유효하지 않은 방입니다. 방 번호를 다시 입력해주세요."
+    });
+    return;
+  }
+
+  next();
+}
+
+//  * 방 번호를 입력 받아서 존재하는 방인지 확인함. (인메모리에 존재하는 번호인지 확인)
+function isRoomExist(req, res, next) {
+  const { roomNumber } = req.params;
+
+  if (!rooms.getRoom(roomNumber)) {
+    res.json({
+      isSuccess: false,
+      message: "존재하지 않는 방입니다. 방 번호를 다시 입력해주세요."
+    });
+    return;
+  }
+
+  next();
+}
+
+//  * 닉네임을 입력받아서 유효한지 확인함 (3자리 이상, 20자리 이하)
+async function isValidNickname(req, res, next) {
+  await check("nickname")
+    .trim()
+    .isLength({ min: 3, max: 20 })
+    .bail()
+    .custom(value => /[가-힣\w]+/g.exec(value)[0] === value)
+    .run(req);
+
+  if (!validationResult(req).isEmpty()) {
+    res.json({
+      isSuccess: false,
+      message: "유효하지 않은 닉네임입니다. 닉네임을 다시 입력해주세요."
+    });
+    return;
+  }
+
+  next();
+}
+
+//  * 닉네임을 입력받아서 중복되는지 확인함 (인메모리 내 같은 닉네임이 존재하는지 확인)
+function isNicknameOverlap(req, res, next) {
+  const { nickname, roomNumber } = req.params;
+
+  const room = rooms.getRoom(roomNumber);
+  const isAlreadyExist = !!room.players.find(
+    player => player.nickname === nickname
+  );
+
+  if (isAlreadyExist) {
+    res.json({
+      isSuccess: false,
+      message: "이미 존재하는 닉네임입니다. 닉네임을 다시 입력해주세요."
+    });
+    return;
+  }
+
+  next();
+}
+
+// param으로 받은 닉네임이 현재 방에서 존재하는지 확인
+function isNicknameExist(req, res, next) {
+  const { nickname, roomNumber } = req.params;
+
+  const room = rooms.getRoom(roomNumber);
+  const isAlreadyExist = !!room.players.find(
+    player => player.nickname === nickname
+  );
+
+  if (!isAlreadyExist) {
+    res.json({
+      isSuccess: false,
+      message: "존재하지 않는 닉네임입니다."
+    });
+    return;
+  }
+
+  next();
+}
+
+module.exports = {
+  isRoomExist,
+  isRoomNumberValid,
+  isNicknameOverlap,
+  isValidNickname,
+  isNicknameExist
+};

--- a/server/routes/apis/room.js
+++ b/server/routes/apis/room.js
@@ -1,0 +1,50 @@
+const express = require("express");
+const {
+  isRoomExist,
+  isRoomNumberValid,
+  isValidNickname,
+  isNicknameOverlap
+} = require("../../middleware/validations");
+
+const router = express.Router();
+
+router.get("/", (req, res) => {
+  res.json({
+    isError: true,
+    message: "방 번호를 입력하세요."
+  });
+});
+
+/**
+ * @api {get} /room/:roomNumber 유효한 방인지 확인 요청
+ */
+router.get("/:roomNumber", isRoomNumberValid, isRoomExist, (req, res) => {
+  res.json({
+    isSuccess: true
+  });
+});
+
+router.get("/:roomNumber/name", isRoomNumberValid, isRoomExist, (req, res) => {
+  res.json({
+    isError: true,
+    message: "닉네임을 입력하세요."
+  });
+});
+
+/**
+ * @api {get} /room/:roomNumber/:nickname 방에서 유효한 닉네임인지 확인 요청
+ */
+router.get(
+  "/:roomNumber/name/:nickname",
+  isRoomNumberValid,
+  isRoomExist,
+  isValidNickname,
+  isNicknameOverlap,
+  (req, res) => {
+    res.json({
+      isSuccess: true
+    });
+  }
+);
+
+module.exports = router;

--- a/server/socket.js
+++ b/server/socket.js
@@ -1,0 +1,72 @@
+const io = require("socket.io")();
+const rooms = require("./models/rooms");
+const roomTemplate = require("./models/templates/room");
+const playerTemplate = require("./models/templates/player");
+
+// function handleOpenRoom() {
+// function isRoomExist(roomNumber) {
+function handleStartQuiz({ roomNumber }) {
+  if (!isRoomExist(roomNumber)) return;
+
+  io.to(roomNumber).emit("start");
+
+  setTimeout(() => {
+    io.to(roomNumber).emit("next", 0);
+  }, 3000);
+}
+
+function handleNextQuiz({ roomNumber, nextQuizIndex }) {
+  if (!isRoomExist(roomNumber)) return;
+
+  io.to(roomNumber).emit("next", nextQuizIndex);
+}
+
+function handlePlayerChoose({
+  roomNumber,
+  nickname,
+  quizIndex,
+  selectItemIndex
+}) {
+  if (!isRoomExist(roomNumber)) return;
+
+  rooms.UpdatePlayerScore({
+    roomNumber,
+    nickname,
+    quizIndex,
+    selectItemIndex
+  });
+}
+
+function handleBreakQuiz({ roomNumber, quizIndex }) {
+  if (!isRoomExist(roomNumber)) return;
+
+  this.join(roomNumber, () => {
+    io.to(this.id).emit("subResult", rooms.getSubResult(roomNumber, quizIndex));
+  });
+
+  io.to(roomNumber).emit("break");
+}
+
+function handleEndQuiz({ roomNumber }) {
+  if (!isRoomExist(roomNumber)) return;
+
+  io.to(roomNumber).emit("end", rooms.getFinalResult(roomNumber));
+}
+
+// function handleEnterPlayer({ roomNumber, nickname }) {
+// function handleLeavePlayer({ roomNumber, nickname }) {
+// function handleCloseRoom() {
+io.on("connection", socket => {
+  socket.on("disconnect", handleCloseRoom.bind(socket));
+  socket.on("openRoom", handleOpenRoom.bind(socket));
+  socket.on("closeRoom", handleCloseRoom.bind(socket));
+  socket.on("start", handleStartQuiz.bind(socket));
+  socket.on("next", handleNextQuiz.bind(socket));
+  socket.on("choose", handlePlayerChoose.bind(socket));
+  socket.on("break", handleBreakQuiz.bind(socket));
+  socket.on("end", handleEndQuiz.bind(socket));
+  socket.on("enterPlayer", handleEnterPlayer.bind(socket));
+  socket.on("leavePlayer", handleLeavePlayer.bind(socket));
+});
+
+module.exports = io;


### PR DESCRIPTION
## 개발 요약 및 파일 설명
- 퀴즈 게임 진행을 위해 Host에서 소켓을 통해 신호를 전송하고, 신호를 받아 퀴즈 데이터를 전달받는 부분을 구현하였습니다.

> - `pages/host/HostGameRoom.js` 
> 게임 진행 페이지, 아래 하위 컴포넌트를 가집니다. 
> - `components/HostLoading.js` 
> 소켓에 `start`신호를 보낸 뒤, 
> `next`신호가 오기 전까지 퀴즈 데이터를 받기 위해 로딩을 표시하는 컴포넌트
> - `components/HostQuizPlaying.js` 
> 게임 시작 이후 컴포넌트. 유저에게 문제를 보여주고, 중간 결과를 보여줍니다. 
> 아래 하위 컴포넌트를 가집니다.
> - `components/HostPlaying.js` 
> 게임이 시작되는 중 카운트 다운을 진행하고, 유저에게 문제를 보여주는 컴포넌트. 
> `next`신호를 보낸 이후 소켓의 `next` 신호에서 다음 인덱스를 보내주면 문제를 출력합니다.
>  - `components/HostSubResult.js`
> 게임 중 중간 결과를 출력하는 컴포넌트. 
> `break`신호를 통해 소켓에서 결과를 받으면 결과를 출력합니다.
> - `reducer/hostGameReducer.js`
> 상태관리를 담당하는 reducer 파일입니다.
> - `server/socket.js`
> 소켓 통신 파일입니다.
> - 정보를 요청하는 api가 post 형태로 구현되어있어, get 형태로 수정하였습니다. 

<details><summary>4주차 시나리오</summary>

- host가 방 리스트 페이지에서 방을 선택하면 방 선택 화면으로 이동한다.
- player들의 대기실 입장이 완료되면 host가 퀴즈를 시작한다.
- 퀴즈가 시작되면 방에 속한 문제들이 설정된 제한 시간에 맞게 진행된다.
- 각 퀴즈의 끝에는 결과 페이지(Player각자의 점수)가 존재한다.
- host가 다음 퀴즈의 시작 버튼을 클릭하면 '3번'으로 이동한다.
- 모든 퀴즈가 종료되면 최종 스코어 보드(10등 까지)가 출력된다.
</details>

## 질문 및 의견
- **socket 연결에 대한 상태관리, reducer**
페이지를 이동하면 소켓의 연결이 끊기는 이슈가 있어, 유저의 정보를 정상적으로 저장하기 힘들었습니다. 
때문에 페이지의 이동 없이 컴포넌트를 갈아끼우는 방식으로 페이지를 구현하였는데, 이렇게 하니 state로 상태를 관리하기엔 너무 많은 것 같아 reducer를 사용해 구현하였습니다. 그런데 reducer는 보통 하나만 두고 전체를 관리하는 용도로 사용한다고 하는데 이런 방식으로 사용해도 괜찮을까요? 
- **api 서버와 소켓 서버의 차이**
현재는 Player의 문제 정답 선택 결과를 socket을 통해 전송해 인메모리 DB에 반영하는데, post로 전송하는 것이 좋을 지, socket으로 전송해 반영할 지 고민이 되는 부분입니다. 
Host에 즉각적으로 출력되는 값은 아니고, 퀴즈의 제한 시간이 끝나면 출력해야 될 값인데 혹시 소켓으로  많은 유저가 한꺼번에 어떤 정보를 전송하는 것은 안좋은 방법일까요? 혹시 어떤 방식이 더 낫다고 생각하시는 지 궁금합니다..!