### PR TITLE
Chore: eslint object-curly-newline에 대한 rule 추가

### DIFF
--- a/client/src/components/common/Modal.js
+++ b/client/src/components/common/Modal.js
@@ -33,6 +33,7 @@ const ModalTitle = styled.div`
   color: ${colors.TEXT_BLACK};
   font-size: 2rem;
   font-weight: bold;
+  text-align: center;
   margin-bottom: 1rem;
   padding-bottom: 1rem;
   border-bottom: 1px solid lightgray;
@@ -64,6 +65,7 @@ const Description = styled.div`
   margin-bottom: 1rem;
   color: ${colors.TEXT_GRAY};
   word-break: keep-all;
+  text-align: center;
   @media (min-width: ${DESKTOP_MIN_WIDTH}) {
     font-size: 1.5rem;
   }

--- a/server/.eslintrc.js
+++ b/server/.eslintrc.js
@@ -25,5 +25,11 @@ module.exports = {
         allowTemplateLiterals: true,
       },
     ],
+    'object-curly-newline': [
+      'error',
+      {
+        ObjectExpression: 'always',
+      },
+    ],
   },
 };


### PR DESCRIPTION
아래와 같은 object 형태에서 object 형태가 깨지면서 prettier가 제대로 적용되지 않아 새로운 rule을 추가하였음. 

```javascript
const object = {
 item1, item2, item3, item4
} = req.params;
```