### PR TITLE
Feat: action의 결과값에 따라 Modal을 유지/닫기 할 수 있는 기능 추가

### DIFF
--- a/client/src/components/common/Modal.js
+++ b/client/src/components/common/Modal.js
@@ -92,7 +92,7 @@ function Modal({
             {closeButton && <Button onClick={closeModal}>{closeButton}</Button>}
             <YellowButton
               onClick={() => {
-                if (action) action();
+                if (action && !action()) return;
                 closeModal();
               }}
             >


### PR DESCRIPTION
## Done
유저의 input 등의 입력 값이 유효하지 않을 때, 실패/성공 결과에 따라 
Modal이 유지되거나 닫히는 것이 UX상 좋다고 판단해 해당 기능을 추가하였음

## Related Issue
#107