### PR TITLE
[PR] Fix : URL로 직접접근시 유효하지 않은 경우 처리 

### DIFF
--- a/client/src/Router.js
+++ b/client/src/Router.js
@@ -7,6 +7,7 @@ import EditPage from './pages/host/EditPage';
 import PlayerGameRoom from './pages/player/PlayerGameRoom';
 import CallBackPage from './pages/login/CallBackPage';
 import SelectRoom from './pages/host/SelectRoom';
+import NotFoundPage from './pages/NotFoundPage';
 
 export default function() {
   return (
@@ -22,6 +23,7 @@ export default function() {
       <Route exact path="/callback" component={CallBackPage} />
       <Route exact path="/host/room/select" component={SelectRoom} />
       <Route exact path="/host/room/detail" component={HostDetailRoom} />
+      <Route path="" component={NotFoundPage} />
     </Router>
   );
 }

--- a/client/src/pages/NotFoundPage.js
+++ b/client/src/pages/NotFoundPage.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { PRIMARY_LIGHT_YELLOW } from '../constants/colors';
+
+const Background = styled.div`
+  height: 100vmin;
+
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  background-color: ${PRIMARY_LIGHT_YELLOW};
+`;
+
+const GameOver = styled.div`
+  font-size: 20rem;
+  font-family: 'CookieRunOTF-Bold';
+
+  @font-face {
+    font-family: 'CookieRunOTF-Bold';
+    src: url('https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_twelve@1.0/CookieRunOTF-Bold00.woff')
+      format('woff');
+    font-weight: normal;
+    font-style: normal;
+  }
+`;
+
+const ErrorCode = styled.div`
+  font-size: 10rem;
+  font-family: 'CookieRunOTF-Bold';
+
+  @font-face {
+    font-family: 'CookieRunOTF-Bold';
+    src: url('https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_twelve@1.0/CookieRunOTF-Bold00.woff')
+      format('woff');
+    font-weight: normal;
+    font-style: normal;
+  }
+`;
+
+function ErrorPage() {
+  return (
+    <Background>
+      <GameOver>GAME OVER</GameOver>
+      <ErrorCode>Error : 404</ErrorCode>
+    </Background>
+  );
+}
+
+export default ErrorPage;

--- a/client/src/pages/player/PlayerGameRoom.js
+++ b/client/src/pages/player/PlayerGameRoom.js
@@ -27,6 +27,14 @@ const Container = styled.div`
 `;
 
 function PlayerGameRoom({ location, history }) {
+  /**
+   * Cannot read property 에러의 경우 state가 없는 경우이므로
+   * state가 undefined인지 검사해주면 된다.
+   * 검사 후 문제가 있는 경우 메인페이지로 강제 이동시킴
+   */
+  if (!location.state) {
+    window.location.href = '/';
+  }
   const { nickname, roomNumber } = location.state;
 
   const socket = io.connect(process.env.REACT_APP_BACKEND_HOST);


### PR DESCRIPTION
1.404 페이지에 대한 처리
2. url로 접근시 property가 없어 생기는 오류 처리.

```javascript
  /**
   * Cannot read property 에러의 경우 state가 없는 경우이므로
   * state가 undefined인지 검사해주면 된다.
   * 검사 후 문제가 있는 경우 메인페이지로 강제 이동시킴
   */
  if (!location.state) {
    window.location.href = '/';
  }
```

에러가 발생할 경우에 대한 처리만 구현.

현재 위와 같은 방식으로 강제로 메인페이지로 이동시킴.

앞으로 회의에서 property 에러가 발생했을 시 어느 페이지로 이동시킬 것인지 결정할 필요 있음.

Related issue : #133