### PR TITLE
[조찬기] w5_리뷰요청_safe guard처리 및 dbManager 구조, 리펙토링관련

### DIFF
--- a/code/PlayerGameRoom.js
+++ b/code/PlayerGameRoom.js
@@ -1,0 +1,99 @@
+import React, { useState, useEffect } from "react";
+import styled from "styled-components";
+import io from "socket.io-client";
+import PropTypes from "prop-types";
+import { Prompt } from "react-router";
+
+import PlayerFooter from "../../components/inGame/PlayerFooter";
+import PlayerWaiting from "../../components/inGame/PlayerWaiting";
+import PlayerQuizLoading from "../../components/inGame/PlayerQuizLoading";
+import PlayerQuiz from "../../components/inGame/PlayerQuiz";
+import PlayerSubResult from "../../components/inGame/PlayerSubResult";
+import PlayerResult from "../../components/inGame/PlayerResult";
+
+/**
+ * string 으로 형태를 바꾸었습니다
+ */
+const VIEW_STATE = {
+  WAITING: "WAITING",
+  IN_QUIZ: "INQUIZ",
+  LOADING: "LOADING",
+  SUB_RESULT: "SUBRESULT",
+  END: "END"
+};
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100vw;
+  height: 100vh;
+`;
+
+function PlayerGameRoom({ location, history }) {
+  /**
+   * Cannot read property 에러의 경우 state가 없는 경우이므로
+   * state가 undefined인지 검사해주어 safe guard 처리를 하고 있습니다
+   *
+   * 이런 방법으로 사용자의 비정상적인 접근을 대부분 처리할 수 있는지 궁금합니다
+   *
+   * 예를들어 다른페이지에서 state가 설정되어 있지만, 아래에서 사용하는 property가
+   * 아닌 다른 property를 가진 채로 들어올 수 있기 때문입니다
+   */
+  if (!location.state) {
+    window.location.href = "/";
+  }
+
+  // ...
+
+  return (
+    <Container>
+      <Prompt message="페이지를 이동하면 방에서 나가게 됩니다. 계속 하시겠습니까?" />
+      {viewState === VIEW_STATE.WAITING && <PlayerWaiting />}
+      {viewState === VIEW_STATE.LOADING && (
+        <PlayerQuizLoading setQuizSet={setQuizSet} roomNumber={roomNumber} />
+      )}
+      {viewState === VIEW_STATE.IN_QUIZ && (
+        <PlayerQuiz
+          quizSet={quizSet}
+          roomNumber={roomNumber}
+          quizIndex={quizIndex}
+          setChoose={setChoose}
+        />
+      )}
+      {viewState === VIEW_STATE.SUB_RESULT && (
+        <PlayerSubResult
+          choose={choose}
+          score={score}
+          setScore={setScore}
+          nickname={nickname}
+          roomNumber={roomNumber}
+          quizIndex={quizIndex}
+        />
+      )}
+      {viewState === VIEW_STATE.END && (
+        <PlayerResult
+          ranking={ranking}
+          roomNumber={roomNumber}
+          nickname={nickname}
+        />
+      )}
+
+      <PlayerFooter nickname={nickname} score={score} />
+    </Container>
+  );
+}
+
+PlayerGameRoom.propTypes = {
+  location: PropTypes.shape({
+    pathname: PropTypes.string.isRequired,
+    state: PropTypes.shape({
+      nickname: PropTypes.string.isRequired,
+      roomNumber: PropTypes.string.isRequired
+    })
+  }).isRequired,
+  history: PropTypes.shape({
+    push: PropTypes.func.isRequired
+  }).isRequired
+};
+
+export default PlayerGameRoom;

--- a/code/PlayerSubResult.js
+++ b/code/PlayerSubResult.js
@@ -1,0 +1,71 @@
+function PlayerSubResultComponent({
+  choose,
+  score,
+  setScore,
+  nickname,
+  roomNumber,
+  quizIndex
+}) {
+  const [result, setResult] = useState({ isCorrect: undefined });
+  const [plusScore, setPlus] = useState(0);
+
+  useEffect(() => {
+    /**
+     * fetch.js의 함수를 호출하는 코드입니다
+     * fetch 이후 결과 (정답, 오답)을 체크하고 state를 변경해 reRender 시키는
+     * 방식으로 구현했습니다.
+     */
+    fetchCheckAnswer(roomNumber, nickname, quizIndex, choose).then(response => {
+      setResult(response);
+
+      if (response.isCorrect) {
+        setPlus(Number(response.score) - score);
+        setScore(response.score);
+      }
+    });
+  }, []);
+
+  /**
+   * 이 경우 fetch후 응답이 오기까지 시간이 걸리기 때문에,
+   * state(result)가 undefined인지 여부로 fetch 응답이 오기까지 다른 컴포넌트를
+   * 보여주고 있습니다
+   *
+   * undefined로 직접 비교가 아닌 다른 방법으로 리펙토링하고 싶은데 어떤 방법이
+   * 좋을까요?
+   */
+  if (result.isCorrect === undefined) {
+    return (
+      <Background color={COLORS.WHITE}>
+        <Message>정답을 확인 중 입니다.</Message>
+      </Background>
+    );
+  }
+
+  if (result.isCorrect === false) {
+    return (
+      <Background color={COLORS.RED}>
+        <Message>틀렸습니다.</Message>
+      </Background>
+    );
+  }
+
+  if (result.isCorrect === true) {
+    return (
+      <Background color={COLORS.GREEN}>
+        <Message>맞았습니다.</Message>
+        <Score>+{plusScore}</Score>
+      </Background>
+    );
+  }
+}
+
+PlayerSubResultComponent.propTypes = {
+  choose: PropTypes.number.isRequired,
+  score: PropTypes.number.isRequired,
+  setScore: PropTypes.func.isRequired,
+  nickname: PropTypes.string.isRequired,
+  roomNumber: PropTypes.string.isRequired,
+  quizIndex: PropTypes.number.isRequired
+};
+
+export default PlayerSubResultComponent;

--- a/code/dbManager.js
+++ b/code/dbManager.js
@@ -1,0 +1,53 @@
+const mysql = require("mysql2/promise");
+
+require("dotenv").config();
+
+const Analysis = require("./tables/Analysis");
+const Item = require("./tables/Item");
+const Quizset = require("./tables/Quizset");
+const Quiz = require("./tables/Quiz");
+const Room = require("./tables/Room");
+const User = require("./tables/User");
+
+/**
+ * dbManager객체는 tables 폴더 내부의 class로 생성된 객체들을 내부 요소로 가지고
+ * 있습니다.
+ *
+ * 내부 class들은 Talbe.js를 상속하고 있으며, Table은 cosntructor로 db의 pool을
+ * 가지고 있고, 아래와 같은 메소드를 가지고 있습니다.
+ *
+ * 1. async query()
+ * 2. async transaction()
+ *
+ * 이러한 구조에서 개선할 부분이 있는지 여쭈어 보고 싶습니다
+ * 특히 database 커넥션 부분에서 검토를 받고 싶습니다
+ */
+
+/**
+ * 데이터베이스에 접근하는 CRUD를 전부 관리하는 객체
+ *
+ * @class DatabaseManager
+ */
+class DatabaseManager {
+  constructor(pool) {
+    this.pool = pool;
+
+    this.analysis = new Analysis(this.pool);
+    this.item = new Item(this.pool);
+    this.quizset = new Quizset(this.pool);
+    this.quiz = new Quiz(this.pool);
+    this.room = new Room(this.pool);
+    this.user = new User(this.pool);
+  }
+}
+
+const dbManager = new DatabaseManager(
+  mysql.createPool({
+    host: process.env.DB_HOST,
+    user: process.env.DB_USER,
+    database: process.env.DB_DATABASE,
+    password: process.env.DB_PASSWORD
+  })
+);
+
+module.exports = dbManager;

--- a/code/fetch.js
+++ b/code/fetch.js
@@ -1,0 +1,67 @@
+import * as address from "../constants/apiAddresses";
+
+async function fetchPost({ url, data, method = "POST" }) {
+  const response = await fetch(url, {
+    method,
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify(data),
+    credentials: "include"
+  });
+  const responseJson = await response.json();
+  return responseJson;
+}
+
+/**
+ * API 주소를 요소별로 관리하다 보니 url의 주소가 너무 길어지고 보기 복잡해지는
+ * 문제가 있었습니다
+ * 이 문제를 해결하기 위해 3가지 방식을 고민해 봤는데,
+ *
+ * 1. url을 return하는 함수들을 만들고 url 주소 문자열은 전부 함수로 관리
+ * 2. 의미를 가지는 요소 하나하나별로 const로 선언해서 관리하기
+ * 3. user, room, player 등은 fetch에서 hardcoding 한 상태로 두기
+ *
+ * 여기서 1번 방법을 사용하는 편이 좋다고 판단했습니다
+ * 예시) const getRoomsAPI = (userId) => '/user/${userId}/rooms'
+ *
+ * 하지만 1번 방법을 사용하면, url 주소를 확인하기 위해 api주소를 관리하는
+ * constant로 들어가서 확인을 해야 하는 문제가 있습니다
+ *
+ * 혹시나 주소 문자열을 return하는 함수에 주석등으로 설명을 달아 현재 파일에서
+ * return 구조를 확인할수 있는지 궁금합니다
+ *
+ * 어떤 방법이 좋아 보이시는지 의견을 묻고 싶습니다
+ */
+
+async function fetchChoose(roomNumber, quizIndex, choose) {
+  // url 양식 : /room/:roomNumber/quiz/:quizIndex/choose/:choose
+  const url = `/${address.roomApiUrl}/${roomNumber}/${address.quiz}/${quizIndex}/${address.choose}/${choose}`;
+  const response = await fetchPost({
+    url
+  });
+  return response;
+}
+
+async function fetchCheckAnswer(roomNumber, nickname, quizIndex, choose) {
+  // url 양식 : /room/:roomNumber/player/:nickname/quiz/:quizIndex/choose/:choose
+  const url = `/${address.roomApiUrl}/${roomNumber}/${address.player}/${nickname}/${address.quiz}/${quizIndex}/${address.choose}/${choose}`;
+  const response = await fetchPost({
+    url
+  });
+  return response;
+}
+
+export {
+  fetchRoomNumber,
+  fetchNickname,
+  fetchToken,
+  fetchQuizSet,
+  fetchChoose,
+  fetchCheckAnswer,
+  fetchRank,
+  fetchRooms,
+  fetchRoomTitle,
+  addRoom,
+  updateRoomTitle
+};

--- a/code/tables/Quizset.js
+++ b/code/tables/Quizset.js
@@ -1,0 +1,19 @@
+const Table = require('./Table');
+const {
+  quizTable,
+  quizsetTable,
+  itemTable,
+} = require('../../../constants/tableName');
+
+class Quizset extends Table {
+  getQuizset(roomId) {
+    const select = `SELECT Q.title AS quizTitle, Q.score, Q.time_limit, Q.image_path, I.title AS itemTitle, I.order, I.is_answer`;
+    const from = `FROM ${quizTable} AS Q JOIN ${itemTable} AS I ON Q.id = I.quiz_id`;
+    const where = `WHERE quizset_id = (SELECT QS.id FROM ${quizsetTable} AS QS WHERE QS.room_id = ?)`;
+    const query = `${select} ${from} ${where};`;
+
+    return this.query(query, roomId);
+  }
+}
+
+module.exports = Quizset;

--- a/code/tables/Table.js
+++ b/code/tables/Table.js
@@ -1,0 +1,92 @@
+/**
+ * 각 테이블의 CRUD를 담당하는 class가 상속하는 객체
+ * 연결, 쿼리 등 공통된 부분을 관리한다
+ *
+ * @class Table
+ * @param pool {mysql.createPool()} database와 연결할 때 사용하는 정보
+ */
+class Table {
+  constructor(pool) {
+    this.pool = pool;
+  }
+
+  /**
+   * connection 후 쿼리를 수행해주는 함수
+   * 풀을 받아옴(연결) - 쿼리 - 풀 반납 순서를 거친다.
+   *
+   * @param {string} query mysql에서 실행할 쿼리
+   * @param {list} args 쿼리의 ?에 들어갈 인자
+   * @returns {object} rows 쿼리 후 받아온 rows를 포함한 객체 (성공시)
+   * @returns {object} 에러 발생 시 return하는 객체 (에러)
+   * @memberof Table
+   */
+  async query(query, ...args) {
+    try {
+      const connection = await this.pool.getConnection(async (conn) => conn);
+
+      try {
+        const [rows] = await connection.query(query, args);
+
+        return {
+          isSuccess: true,
+          data: JSON.parse(JSON.stringify(rows)),
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          message: error.message,
+        };
+      } finally {
+        connection.release();
+      }
+    } catch (error) {
+      return {
+        isError: true,
+        message: error.message,
+      };
+    }
+  }
+
+  /**
+   * connection 후 트랜잭션을 수행해주는 함수
+   * 풀을 받아옴(연결) - 트랜잭션 시작 - 쿼리 - 커밋/롤백 - 풀 반납 순서를 거친다.
+   *
+   * @param {string} query mysql에서 실행할 쿼리
+   * @param {list} args 쿼리의 ?에 들어갈 인자
+   * @returns {object} rows 쿼리 후 받아온 rows를 포함한 객체 (성공시)
+   * @returns {object} 에러 발생 시 return하는 객체 (에러)
+   * @memberof Table
+   */
+  async transaction(query, ...args) {
+    try {
+      const connection = await this.pool.getConnection(async (conn) => conn);
+
+      try {
+        await connection.beginTransaction();
+        const [rows] = await connection.query(query, args);
+        await connection.commit();
+
+        return {
+          isSuccess: true,
+          data: JSON.parse(JSON.stringify(rows)),
+        };
+      } catch (error) {
+        await connection.rollback();
+
+        return {
+          isError: true,
+          message: error.message,
+        };
+      } finally {
+        connection.release();
+      }
+    } catch (error) {
+      return {
+        isError: true,
+        message: error.message,
+      };
+    }
+  }
+}
+
+module.exports = Table;


### PR DESCRIPTION
# Week 5 review 요청

## 파일 설명

```sh
code 폴더 구조
|-- PlayerGameRoom.js
|-- PlayerSubresult.js
|-- dbManager.js
|-- fetch.js
`-- tables          /dbManaer.js에서 require하는 객체들
    |-- Quizset.js
    `-- Table.js
```

## 코드 리뷰 요청 내용

### 데이터베이스의 connection을 관리하는 dbManager 객체

dbManager.js에 주석으로 달아놓았습니다.

### 정답 선택과 정답 확인 fetch 요청을 나누는것

현재 각 컴포넌트마다 사용하는 로직을 구분하기 위해

정답 선택 API 요청과, 정답 확인 API 요청을 나눠놓은 상태입니다.

이를 한번의 API요청으로 합칠 수도 있을 것 같은데,

로직 별로 구별이 되도록 두 개로 나누는 것이 좋은지,

API 서버의 부하를 줄이기 위해 하나의 요청으로 합치는 것이 좋은지

의견을 묻고 싶습니다.

### 플레이어 중간결과 페이지의 state에 따른 다른 컴포넌트 render

PlayerSubResult.js에 주석으로 달아놓았습니다.

### property가 없는 오류 처리

PlayerGameRoom.js에 주석으로 달아놓았습니다.
