### PR TITLE
[PR] Fix: FlexibleInput에서 한글을입력할 때 생기는 오류 제거

### DIFF
--- a/client/src/components/common/FlexibleInput.js
+++ b/client/src/components/common/FlexibleInput.js
@@ -125,18 +125,18 @@ function FlexibleInput({
   }
 
   function handleInput(event) {
-    let value = event.target.textContent;
+    let testContent = event.target.textContent;
+    let value = testContent;
 
     if (value.length >= maxLength) {
       value = value.substring(0, maxLength);
       if (inputValue.length === maxLength) value = inputValue;
 
-      event.target.textContent = value;
+      testContent = value;
       warningRef.current.textContent = `${maxLength}글자를 넘을 수 없습니다`;
     }
 
     setInputValue(value);
-    if (callback !== undefined) callback(value);
   }
 
   return (
@@ -146,7 +146,7 @@ function FlexibleInput({
         onKeyDown={handleKeyDown}
         onInput={handleInput}
         onFocus={() => setFocus(true)}
-        onBlur={() => setFocus(false)}
+        onBlur={() => callback(inputValue)}
         mobileFontSize={mobileFontSize}
       />
 

--- a/client/src/components/common/FlexibleInput.js
+++ b/client/src/components/common/FlexibleInput.js
@@ -125,14 +125,15 @@ function FlexibleInput({
   }
 
   function handleInput(event) {
-    let testContent = event.target.textContent;
-    let value = testContent;
+    const { target } = event;
+    let value = event.target.textContent;
 
     if (value.length >= maxLength) {
       value = value.substring(0, maxLength);
       if (inputValue.length === maxLength) value = inputValue;
 
-      testContent = value;
+      target.textContent = value;
+
       warningRef.current.textContent = `${maxLength}글자를 넘을 수 없습니다`;
     }
 


### PR DESCRIPTION
기존 방식은 글자를 입력할 때마다 callback이 수행되어 한글 입력이 제대로
수행되지 않는 문제가 존재했음.
이를 blur 될 때 (focus out)만 callback을 호출하도록 변경.

Related issue : #161