### PR TITLE
[이수정] w6_리뷰요청_리팩토링 및 유저의 게임 방 삭제 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/client/src/components/selectRoom/RoomList.js
+++ b/client/src/components/selectRoom/RoomList.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+import * as colors from '../../constants/colors';
+import { deleteRoom } from '../../utils/fetch';
+import deleteButtonImage from '../../assets/images/deleteButton.png';
+
+/**
+ * Styled-component 생략
+ */
+
+function RoomList({ rooms, history, setRooms }) {
+  function handleRoomClick(e) {
+    if (e.defaultPrevented) return;
+
+    const roomTitle = e.target.textContent;
+    const roomId = rooms.find((room) => room.title === roomTitle).id;
+
+    history.push({
+      pathname: '/host/room/detail',
+      state: {
+        roomId,
+      },
+    });
+  }
+
+  function handleDeleteRoomClick(e) {
+    const roomTitle = e.target.previousElementSibling.textContent;
+    const roomId = rooms.find((room) => room.title === roomTitle).id;
+
+    deleteRoom({ roomId }).then((response) => {
+      if (response.isError) {
+        alert('오류로 인해 방이 삭제되지 않았습니다');
+        return;
+      }
+      setRooms(rooms.filter((room) => room.id !== roomId));
+    });
+
+    e.preventDefault();
+  }
+
+  return rooms.map((room) => (
+    <RoomWrapper key={room.id} onClick={handleRoomClick}>
+      <RoomFrame>
+        <RoomDoor>
+          <DoorKnob />
+        </RoomDoor>
+      </RoomFrame>
+      <RoomTitle>{room.title}</RoomTitle>
+      <DeleteRoomButton onClick={handleDeleteRoomClick} />
+    </RoomWrapper>
+  ));
+}
+
+RoomList.propTypes = {
+  rooms: PropTypes.arrayOf(PropTypes.object),
+};
+
+export default RoomList;

--- a/client/src/pages/host/HostGameRoom.js
+++ b/client/src/pages/host/HostGameRoom.js
@@ -1,0 +1,86 @@
+import React, { useState, useEffect, useReducer } from 'react';
+import { Prompt } from 'react-router';
+import styled from 'styled-components';
+import io from 'socket.io-client';
+import PropTypes from 'prop-types';
+
+import HostFooter from '../../components/inGame/HostFooter';
+import HostWaitingRoom from '../../components/inGame/HostWaitingRoom';
+import HostLoading from '../../components/inGame/HostLoading';
+import HostQuizPlayingRoom from '../../components/inGame/HostQuizPlayingRoom';
+import GameResult from '../../components/inGame/HostResult';
+import {
+  roomReducer,
+  initialRoomState,
+  HostGameAction,
+  HostGameContext,
+} from '../../reducer/hostGameReducer';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100vw;
+  height: 100vh;
+`;
+
+function HostGameRoom({ location }) {
+  if (!location.state) {
+    window.location.href = '/host/room/select';
+  }
+
+  const socket = io.connect(process.env.REACT_APP_BACKEND_HOST);
+  const [roomState, dispatcher] = useReducer(roomReducer, initialRoomState);
+  const [ranking, setRanking] = useState([]);
+
+  useEffect(() => {
+    dispatcher({ type: HostGameAction.SET_SOCKET, socket });
+    socket.emit('openRoom', { roomId: location.state.roomId });
+    socket.on('openRoom', ({ roomNumber }) => {
+      dispatcher({ type: HostGameAction.SET_ROOM_NUMBER, roomNumber });
+    });
+
+    function blockClose(e) {
+      e.returnValue = 'warning';
+    }
+
+    window.addEventListener('beforeunload', blockClose);
+    window.addEventListener('unload', () => socket.emit('closeRoom'));
+    return () => {
+      socket.emit('closeRoom');
+      window.removeEventListener('beforeunload', blockClose);
+    };
+  }, []);
+
+  //   socket.on('enterPlayer', (players) => {
+  //   socket.on('leavePlayer', (players) => {
+  //   socket.on('next', (nextQuizIndex) => {
+  //   socket.on('subResult', (subResult) => {
+  //   socket.on('end', (orderedRanking) => {
+
+  return (
+    <Container>
+      {roomState.pageState !== 'END' && (
+        <Prompt message="페이지를 이동하면 방이 닫힐 수 있습니다. 계속 하시겠습니까?" />
+      )}
+      <HostGameContext.Provider value={{ dispatcher, roomState }}>
+        {
+          {
+            WAITING: <HostWaitingRoom />,
+            LOADING: <HostLoading />,
+            PLAYING: <HostQuizPlayingRoom />,
+            END: <GameResult ranking={ranking} />,
+          }[roomState.pageState]
+        }
+      </HostGameContext.Provider>
+      <HostFooter roomNumber={roomState.roomNumber} />
+    </Container>
+  );
+}
+
+HostGameRoom.propTypes = {
+  location: PropTypes.shape({
+    state: PropTypes.object.isRequired,
+  }).isRequired,
+};
+
+export default HostGameRoom;

--- a/client/src/pages/host/SelectRoom.js
+++ b/client/src/pages/host/SelectRoom.js
@@ -1,0 +1,110 @@
+import React, { useState, useEffect, useContext } from 'react';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+
+import * as colors from '../../constants/colors';
+import Header from '../../components/common/Header';
+import { YellowButton } from '../../components/common/Buttons';
+import Modal from '../../components/common/Modal';
+import { ModalContext } from '../../components/common/ModalProvider';
+import FlexibleInput from '../../components/common/FlexibleInput';
+import { fetchRooms, addRoom } from '../../utils/fetch';
+import RoomList from '../../components/selectRoom/RoomList';
+
+/**
+ * Styled-component 생략
+ */
+
+async function getRooms({ userId }) {
+  const result = await fetchRooms({ userId }).then((response) => {
+    if (response.isSuccess) return response.data;
+    return [];
+  });
+  return result;
+}
+
+function parsingUserNaverId() {
+  const cookies = document.cookie.split(';').map((cookie) => cookie.split('='));
+  const naverId = cookies.find((cookie) => cookie[0] === 'naverId');
+  return naverId[1];
+}
+
+function SelectRoom({ history }) {
+  const [rooms, setRooms] = useState([]);
+  const [userId, setUserId] = useState('');
+  const [inputValue, setInputValue] = useState('');
+  const { openModal } = useContext(ModalContext);
+
+  useEffect(() => {
+    try {
+      setUserId(parsingUserNaverId());
+    } catch (err) {
+      window.location.href = '/';
+    }
+  }, []);
+
+  useEffect(() => {
+    if (userId)
+      getRooms({ userId }).then((roomList) => {
+        setRooms(roomList);
+      });
+  }, [userId]);
+
+  function handleCreateButtonClick() {
+    if (!inputValue.trim()) {
+      alert('방의 이름을 입력하세요');
+      return false;
+    }
+
+    if (rooms.find((room) => room.title === inputValue)) {
+      alert('방의 이름은 중복될 수 없습니다');
+      return false;
+    }
+
+    addRoom({ userId, roomTitle: inputValue.trim() }).then((response) => {
+      if (response.isError) {
+        alert('방이 오류로 인해 추가되지 못했습니다');
+        return;
+      }
+      setRooms([...rooms, { id: response.data.insertId, title: inputValue }]);
+    });
+
+    return true;
+  }
+
+  return (
+    <Container>
+      <Header />
+      <Main>
+        <ListHeader>
+          <RoomCounter>{`방 ${rooms.length}개`}</RoomCounter>
+          <YellowButton onClick={openModal}>방 만들기</YellowButton>
+        </ListHeader>
+        <RoomContainer>
+          <RoomList rooms={rooms} history={history} setRooms={setRooms} />
+        </RoomContainer>
+      </Main>
+      <Modal
+        title="새로운 방 추가"
+        description="새로 추가할 방의 이름을 입력하세요"
+        closeButton="취소"
+        actionButton="만들기"
+        action={handleCreateButtonClick}
+      >
+        <FlexibleInput
+          placeholder="방 이름을 입력하세요"
+          maxLength={26}
+          callback={setInputValue}
+        />
+      </Modal>
+    </Container>
+  );
+}
+
+SelectRoom.propTypes = {
+  history: PropTypes.shape({
+    push: PropTypes.func.isRequired,
+  }).isRequired,
+};
+
+export default SelectRoom;

--- a/client/src/reducer/hostGameReducer.js
+++ b/client/src/reducer/hostGameReducer.js
@@ -1,0 +1,103 @@
+import { createContext } from 'react';
+
+const HostGameAction = {
+  SET_SOCKET: 'SET_SOCKET',
+  SET_ROOM_NUMBER: 'SET_ROOM_NUMBER',
+  SET_PLAYERS: 'SET_PLAYERS',
+  GAME_START: 'GAME_START',
+  SET_CURRENT_QUIZ: 'SET_CURRENT_QUIZ',
+  REQUEST_NEXT_QUIZ: 'REQUEST_NEXT_QUIZ',
+  REQUEST_SUB_RESULT: 'REQUEST_SUB_RESULT',
+  SET_SUB_RESULT: 'SET_SUB_RESULT',
+  SET_ENTIRE_QUIZ: 'SET_ENTIRE_QUIZ',
+  REQUEST_QUIZ_END: 'REQUEST_QUIZ_END',
+  SHOW_SCOREBOARD: 'SHOW_SCOREBOARD',
+};
+
+const HOST_PAGE_STATE = {
+  WAITING: 'WAITING',
+  LOADING: 'LOADING',
+  PLAYING: 'PLAYING',
+  END: 'END',
+};
+
+const roomReducer = (state, action) => {
+  switch (action.type) {
+    case HostGameAction.SET_SOCKET: {
+      return { ...state, socket: action.socket };
+    }
+    case HostGameAction.SET_ROOM_NUMBER: {
+      return { ...state, roomNumber: action.roomNumber };
+    }
+    case HostGameAction.SET_PLAYERS: {
+      return { ...state, players: action.players };
+    }
+    case HostGameAction.GAME_START: {
+      state.socket.emit('start', { roomNumber: state.roomNumber });
+      return { ...state, pageState: HOST_PAGE_STATE.LOADING };
+    }
+    case HostGameAction.SET_CURRENT_QUIZ: {
+      return {
+        ...state,
+        currentQuiz: {
+          ...state.fullQuizData[action.index],
+          index: action.index,
+        },
+        pageState: HOST_PAGE_STATE.PLAYING,
+      };
+    }
+    case HostGameAction.REQUEST_NEXT_QUIZ: {
+      state.socket.emit('next', {
+        roomNumber: state.roomNumber,
+        nextQuizIndex: state.currentQuiz.index + 1,
+      });
+
+      return state;
+    }
+    case HostGameAction.REQUEST_SUB_RESULT: {
+      state.socket.emit('break', {
+        roomNumber: state.roomNumber,
+        quizIndex: state.currentQuiz.index,
+      });
+
+      return state;
+    }
+    case HostGameAction.SET_SUB_RESULT: {
+      return { ...state, quizSubResult: action.subResult };
+    }
+    case HostGameAction.SET_ENTIRE_QUIZ: {
+      return {
+        ...state,
+        fullQuizData: action.data,
+        totalQuizCount: action.data.length,
+      };
+    }
+    case HostGameAction.REQUEST_QUIZ_END: {
+      state.socket.emit('end', {
+        roomNumber: state.roomNumber,
+      });
+
+      return state;
+    }
+    case HostGameAction.SHOW_SCOREBOARD: {
+      return { ...state, pageState: HOST_PAGE_STATE.END };
+    }
+    default:
+      return state;
+  }
+};
+
+const initialRoomState = {
+  roomNumber: '',
+  players: [],
+  socket: null,
+  fullQuizData: [],
+  totalQuizCount: 0,
+  pageState: HOST_PAGE_STATE.WAITING,
+  currentQuiz: null,
+  quizSubResult: null,
+};
+
+const HostGameContext = createContext();
+
+export { initialRoomState, roomReducer, HostGameAction, HostGameContext };

--- a/server/models/template/room.js
+++ b/server/models/template/room.js
@@ -1,0 +1,27 @@
+/**
+ * 기존에 배열 형태로 방의 정보를 저장하고 있는 인메모리 DB의 구조를 Map 형태로 변경하였습니다.
+ * 기존의 경우 배열에서 방의 번호를 찾고, 그 안에서 nickname이 동일한 유저를 찾는데 시간 복잡도가 높아
+ * Map 형태로 변경하여 방의 번호를 key, 아래 template을 value로 갖는 구조로 변경하였습니다.
+ * rooms.js 파일에서 이러한 형태의 인메모리 DB를 이용하고 있습니다.
+ */
+
+// 기존 형태
+const roomTemplate = () => ({
+  roomNumber: '',
+  players: [],
+  hostId: '',
+  package: [],
+  currentQuizIndex: -1,
+  quizSet: [],
+});
+
+// 변경된 형태
+const roomTemplate = () => ({
+  players: new Map(),
+  hostId: '',
+  quizSet: [],
+});
+
+module.exports = {
+  roomTemplate,
+};


### PR DESCRIPTION
## 개발상황 요약, 질문 및 의견
- **Host의 GameRoom을 리팩토링 하였습니다.** (#187)
  - 다른 팀원에게 리뷰해주셨던 enum을 사용해봤는데 훨씬 보기 편해진 것 같아 좋은 것 같습니다. 
    감사합니다. 
  - Host의 GameRoom을 리팩토링 하면서, 모든 컴포넌트에 dispatcher와 state를 넘겨주는 부분이 번거로워 Context API를 활용하는 방식으로 방법을 바꿨습니다. 
  처음에는 GameRoom에서 `HostGameContext`를 `export`하고, component에서 이를 불러서 사용했는데  lint에서 상호참조 이슈가 발생해 Reducer에 Context를 두고 사용하게 되었는데요. 
  이런 방식도 괜찮은가요?
- **서버의 인메모리 DB 구조를 변경하였습니다.** (#178)
  - 기존 방식이 배열로 구현되어 시간 복잡도가 클 수 있다는 이슈가 있어, Map 형태로 변경하였습니다.
- **유저가 방을 삭제하는 기능을 추가하였습니다.** (#183)
  - 방을 삭제하면서 성공 응답이 오면 방 목록을 따로 갱신하지 않고 삭제를 눌렀던 방을 없애는 방식으로 구현된 상태입니다. 
  성공 응답이 왔는데 한번 더 갱신할 필요는 없다고 판단해 이런 방식으로 구현하게 되었는데 갱신을 하는 편이 더 안전할까요?

___

지난번에 알려주신 stopPropagation에 대한 정보 감사합니다! 