### PR TITLE
[PR] 배포 후 치명적인 버그를 발견해서 수정함

### DIFF
--- a/client/src/components/edit/Section.js
+++ b/client/src/components/edit/Section.js
@@ -56,6 +56,7 @@ function Section({ roomId, quizsetId }) {
       const { quizset } = result.data;
       dispatch({ type: actionTypes.READ_QUIZSET, quizset });
     }
+    dispatch({ type: actionTypes.RESET_DELETE_QUIZZES });
 
     dispatch({ type: actionTypes.UPDATE_IDS, roomId, quizsetId });
 

--- a/client/src/components/edit/SideBar.js
+++ b/client/src/components/edit/SideBar.js
@@ -144,9 +144,14 @@ function SideBar() {
   }
 
   useEffect(() => {
-    window.addEventListener('resize', () =>
-      setWindowSize({ width: window.innerWidth, height: window.innerHeight }),
-    );
+    function changeWindowSize() {
+      setWindowSize({ width: window.innerWidth, height: window.innerHeight });
+    }
+
+    window.addEventListener('resize', changeWindowSize);
+    return () => {
+      window.removeEventListener('resize', changeWindowSize);
+    };
   }, []);
 
   useEffect(() => {

--- a/client/src/reducer/hostEditReducer.js
+++ b/client/src/reducer/hostEditReducer.js
@@ -35,6 +35,7 @@ const actionTypes = {
   DELETE_QUIZ: 10,
   UPDATE_IDS: 11,
   CHANGE_LOADING: 12,
+  RESET_DELETE_QUIZZES: 13,
 };
 
 const loadingTypes = {
@@ -167,6 +168,9 @@ const quizsetReducer = (quizsetState, action) => {
     }
     case actionTypes.CHANGE_LOADING: {
       return { ...quizsetState, loadingType: action.loadingType };
+    }
+    case actionTypes.RESET_DELETE_QUIZZES: {
+      return { ...quizsetState, deletedQuizzes: [] };
     }
     default:
       return quizsetState;


### PR DESCRIPTION
- SideBar useEffect 경고메세지 해결
  - window event listener를 제거하지 않아서 경고 메세지를 출력하였음
  - unmout될 때 event listener를 삭제하는 방식으로 해결

- 퀴즈 삭제를 저장하지 않고 페이지 변경 후 다시 돌아오고 저장하면 퀴즈가 삭제되는 문제
  - editPage가 처음 실행될 때 deletedQuizzes를 초기화 시켜서 해결