### PR TITLE
!HOTFIX: 새로고침, 창닫기와 관련된 이슈 수정

### DIFF
--- a/client/src/components/inGame/PlayerSubResult.js
+++ b/client/src/components/inGame/PlayerSubResult.js
@@ -43,7 +43,7 @@ function PlayerSubResult({ plusScore, score, setScore, isAnswer }) {
     if (isAnswer) {
       setScore(score + plusScore);
     }
-  }, [plusScore, setScore, isAnswer]);
+  }, [isAnswer]);
 
   return (
     <>

--- a/client/src/components/mainPage/EnterRoomNumber.js
+++ b/client/src/components/mainPage/EnterRoomNumber.js
@@ -65,13 +65,13 @@ function EnterRoomNumber() {
   }
 
   function handlePressEnter(e) {
+    if (e.which === 229) return;
     if (e.ctrlKey || e.key === 'Backspace') return;
     if (e.key === 'Enter') {
       handleEnterButtonClick();
       return;
     }
-
-    if (/^\d/.test(e.key)) {
+    if (/[^0-9]/.test(e.key)) {
       onToast('방번호는 숫자만 입력할 수 있습니다');
       return;
     }

--- a/server/models/rooms.js
+++ b/server/models/rooms.js
@@ -57,14 +57,15 @@ class Rooms {
   }
 
   async setQuizSet(roomNumber, roomId) {
-    const { data } = await dbManager.quizset.getQuizset(roomId);
+    const { isSuccess, data } = await dbManager.quizset.getQuizset(roomId);
+    if (!isSuccess) return;
 
     const quizset = [];
     const previousArray = [];
     let quizIndex = -1;
 
-    data.forEach((currentValue) => {
-      if (!previousArray.find((element) => element === currentValue.id)) {
+    data.forEach(currentValue => {
+      if (!previousArray.find(element => element === currentValue.id)) {
         const currentQuiz = quizTemplate();
         currentQuiz.title = currentValue.quizTitle;
         currentQuiz.score = currentValue.score;
@@ -106,8 +107,8 @@ class Rooms {
     return String(newRoomNumber);
   }
 
-  setNewPlayer(roomNumber, nickname) {
-    this.getRoom(roomNumber).players.set(nickname, 0);
+  setNewPlayer(roomNumber, nickname, score = 0) {
+    this.getRoom(roomNumber).players.set(nickname, score);
 
     return this.getPlayers(roomNumber);
   }
@@ -135,6 +136,7 @@ class Rooms {
   deletePlayer(roomNumber, nickname) {
     const room = this.getRoom(roomNumber);
     room.submittedPlayers.delete(nickname);
+    room.deletedPlayers.set(nickname, room.players.get(nickname));
     return room.players.delete(nickname);
   }
 
@@ -166,12 +168,21 @@ class Rooms {
     return false;
   }
 
+  clearDeletedPlayers(roomNumber) {
+    this.getRoom(roomNumber).deletedPlayers.clear();
+    console.log(this.getRoom(roomNumber).deletedPlayers);
+  }
+
   isRoomExist(roomNumber) {
     return this.rooms.has(roomNumber);
   }
 
   isPlayerExist(roomNumber, nickname) {
     return this.getRoom(roomNumber).players.has(nickname);
+  }
+
+  isRefreshingPlayer(roomNumber, nickname) {
+    return this.getRoom(roomNumber).deletedPlayers.get(nickname);
   }
 
   isLastSubmit({ roomNumber, nickname }) {

--- a/server/models/templates/room.js
+++ b/server/models/templates/room.js
@@ -1,6 +1,7 @@
 const roomTemplate = () => ({
   players: new Map(),
   submittedPlayers: new Map(),
+  deletedPlayers: new Map(),
   hostId: '',
   quizSet: [],
 });


### PR DESCRIPTION
## Done
- 방 번호 입력 시 숫자를 입력할 때도 경고가 뜨는 현상 수정
- socket의 연결을 여러번 맺고 있는 현상 수정
- 네트워크 에러에 대한 setQuizset 예외처리 추가
- 불필요한 socket room join문 삭제
- 창 닫기 시 Player가 나가는 것이 반영되지 않는 현상 수정
  - ?: refresh와 창 닫기 이벤트를 구분하지 못해 발생하는 현상
프론트에서 구분이 어렵다고 판단되어, 프론트에서는 무조건 닫는 신
호를 보내도록 변경하였음. 중간결과를 받기 전까지는 나갔던 유저들을
저장해 뒀다가, 해당 퀴즈가 끝나기 전까지 들어오면 그대로 유지되고
이후에 들어오면 초기화 되도록 구현하였음.
- 퀴즈 점수가 이전과 다를 때 Player의 푸터 점수가 늘어나는 현상 수정