### PR TITLE
Feat: 중간에 들어온 플레이어를 나중에 추가되도록 하는 기능 추가

### DIFF
--- a/server/models/rooms.js
+++ b/server/models/rooms.js
@@ -62,6 +62,17 @@ class Rooms {
       : -1;
   }
 
+  setWaitingPlayersToGame(roomNumber) {
+    const { waitingPlayers } = this.getRoom(roomNumber);
+
+    while (waitingPlayers.length) {
+      const { nickname, score } = waitingPlayers.pop();
+      this.setNewPlayer(roomNumber, nickname, score);
+    }
+
+    return this.getPlayers(roomNumber);
+  }
+
   setNextQuizIndex(roomNumber) {
     this.getRoom(roomNumber).quizIndex += 1;
     return this.getQuizIndex(roomNumber);
@@ -149,6 +160,13 @@ class Rooms {
     return [isCorrect, score];
   }
 
+  updateWaitingPlayers({ roomNumber, nickname, score }) {
+    this.getRoom(roomNumber).waitingPlayers.push({
+      nickname,
+      score,
+    });
+  }
+
   deletePlayer(roomNumber, nickname) {
     const room = this.getRoom(roomNumber);
     room.submittedPlayers.delete(nickname);
@@ -186,6 +204,10 @@ class Rooms {
 
   clearDeletedPlayers(roomNumber) {
     this.getRoom(roomNumber).deletedPlayers.clear();
+  }
+
+  isQuizPlaying(roomNumber) {
+    return this.getRoom(roomNumber).quizIndex > -1;
   }
 
   isRoomExist(roomNumber) {

--- a/server/models/templates/room.js
+++ b/server/models/templates/room.js
@@ -2,9 +2,10 @@ const roomTemplate = () => ({
   players: new Map(),
   submittedPlayers: new Map(),
   deletedPlayers: new Map(),
+  waitingPlayers: [],
   hostId: '',
   quizSet: [],
-  quizIndex: 0,
+  quizIndex: -1,
 });
 
 module.exports = {


### PR DESCRIPTION
## Done
- 중간에 들어온 플레이어를 나중에 추가되도록 하였습니다
  - 퀴즈가 진행 중이면 소켓 room에 연결만하고 대기열에 넣어뒀다가,
next 신호가 오면 그 때 대기열에 있는 유저를 players map에 넣고 host에게 enterPlayer 신호를 전송.